### PR TITLE
chore(package): reorganize dependencies and devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,12 +11,8 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.0.1",
     "@sentry/nextjs": "^8.19.0",
-    "@types/node": "20.3.3",
-    "@types/react": "^18.2.66",
-    "@types/react-dom": "18.2.6",
     "@vercel/analytics": "^1.3.2",
     "@vercel/speed-insights": "^1.0.14",
-    "eslint-config-next": "13.4.7",
     "framer-motion": "^11.0.8",
     "mongoose": "^7.3.1",
     "next": "14.0.4",
@@ -27,15 +23,19 @@
     "react-redux": "^9.0.4",
     "react-toastify": "^10.0.5",
     "redux-persist": "^6.0.0",
-    "sass": "^1.63.6",
-    "typescript": "5.1.6"
+    "sass": "^1.63.6"
   },
   "devDependencies": {
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/github": "^10.1.1",
+    "@types/node": "20.3.3",
+    "@types/react": "^18.2.66",
+    "@types/react-dom": "18.2.6",
     "autoprefixer": "^10.4.18",
+    "eslint-config-next": "13.4.7",
     "postcss": "^8.4.35",
     "prettier": "^2.8.8",
-    "semantic-release": "^24.0.0"
+    "semantic-release": "^24.0.0",
+    "typescript": "5.1.6"
   }
 }


### PR DESCRIPTION
Moved TypeScript types, ESLint config, and TypeScript to devDependencies as they are only required during development. Kept runtime dependencies like Next.js, React, and Sass in dependencies for production use.